### PR TITLE
Update SceneDelegate.swift

### DIFF
--- a/iOS/Vonage/Application/SceneDelegate.swift
+++ b/iOS/Vonage/Application/SceneDelegate.swift
@@ -83,6 +83,7 @@ extension SceneDelegate {
             .sink { (user) in
                 if (user == nil) {
                     let loginVC = self.createViewController(LoginViewController.self)
+                    self.nav = nil //Needs to set this back to nil, or scene will not change to dialerVC when user tries to login again after logout - _beejay
                     self.window?.rootViewController = loginVC
                 }
                 else {


### PR DESCRIPTION
This change will fix the issue where when a user logs out and tries to login again, the scene does not change back to dialerVC. The fix was to sent` self.nav` back to `nil `so the check ` if (self.nav == nil)` on under the next `else` will work